### PR TITLE
Fixed FD leak in Epoller

### DIFF
--- a/service/epoller.cc
+++ b/service/epoller.cc
@@ -42,6 +42,7 @@ init(int maxFds)
 {
     //cerr << "initializing epoller at " << this << endl;
     //backtrace();
+    close();
 
     epoll_fd = epoll_create(maxFds);
     if (epoll_fd == -1)


### PR DESCRIPTION
FD leak was when using classes derived from RestServiceEndpoint. 
Firstly Epoller::init() was called from MessageLoop constructor, and second from RestServiceEndpoint::init() by calling MessageLoop::init().
