### PR TITLE
fix parsing of GOOG128 type (len>=26)

### DIFF
--- a/types/id.cc
+++ b/types/id.cc
@@ -184,7 +184,7 @@ parse(const char * value, size_t len, Type type)
     }
 
     if ((type == UNKNOWN || type == GOOG128)
-        && len == 26 && value[0] == 'C' && value[1] == 'A'
+        && len >= 26 && value[0] == 'C' && value[1] == 'A'
         && value[2] == 'E' && value[3] == 'S' && value[4] == 'E') {
 
         // Google ID: --> CAESEAYra3NIxLT9C8twKrzqaA
@@ -206,8 +206,8 @@ parse(const char * value, size_t len, Type type)
                 else return -1;
             };
 
-        bool error = false;
-        for (unsigned i = 5;  i < 26 && !error;  ++i) {
+        auto error = false;
+        for (auto i = 5;  i < len && !error;  ++i) {
             int v = b64Decode(value[i]);
             if (v == -1) error = true;
             res = (res << 6) | v;


### PR DESCRIPTION
Hi
Google user identifier seen at the moment on AdEx are 27 char. 
I am not sure about potential side effects of this --  here's what Jeremy said when discussing the topic on Skype:

"there are some implications for us internally to change it, as it changes the value of hash() and we have files serialized with those hashes"

But I don't  see why, since the hash should be computed on the internal 128 bits. 

Cheers
