### PR TITLE
Fix empty field handling

### DIFF
--- a/logger/log_message_splitter.h
+++ b/logger/log_message_splitter.h
@@ -49,7 +49,7 @@ struct LogMessageSplitter {
         const char * start = data;
         const char * end = start + str.size();
 
-        while (start < end && numFields < maxFields) {
+        while (start <= end && numFields < maxFields) {
             offsets[numFields++] = start - data;
             while (start < end && *start != split)
                 ++start;


### PR DESCRIPTION
To reproduce the bug fixed by this commit, call
logMessage("CHANNEL", "", "", "");

Expected output when splitting the string (passed into the logMessage method in the logger) into the fields:
numFields: 4
field[0]: Timestamp
field[1]: ""
field[2]: ""
field[3]: ""

But the resulting output was:
numFields: 3
field[0]: Timestamp
field[1]: ""
field[2]: "\t"
