### PR TITLE
Logger not closing outputs when deleted

### DIFF
--- a/logger/multi_output.cc
+++ b/logger/multi_output.cc
@@ -27,6 +27,9 @@ MultiOutput()
 MultiOutput::
 ~MultiOutput()
 {
+    for (auto &output : outputs) {
+        output.second->close();
+    }
 }
 
 void


### PR DESCRIPTION
- The logger must close the outputs when deleted, otherwise we will
  have files not closed, and because of that, invalid compressed files.
