### PR TITLE
JSON Endpoint: Handle content-type-less requests.

### DIFF
--- a/service/json_endpoint.cc
+++ b/service/json_endpoint.cc
@@ -29,7 +29,8 @@ void
 JsonConnectionHandler::
 handleHttpHeader(const HttpHeader & header)
 {
-    if (header.contentType.find("json") == string::npos
+    if (!header.contentType.empty()
+        && header.contentType.find("json") == string::npos
         && header.contentType.find("text") == string::npos)
         throw Exception("invalid content type '%s' for JSON",
                         header.contentType.c_str());


### PR DESCRIPTION
This way we support clients that don't send content type.
