### PR TITLE
Add Optional::emplace() - as in std::optional.

### DIFF
--- a/types/basic_value_descriptions.h
+++ b/types/basic_value_descriptions.h
@@ -461,6 +461,11 @@ struct Optional: public std::unique_ptr<T> {
     {
         std::unique_ptr<T>::swap(other);
     }
+
+    void emplace()
+    {
+        this->reset(new T{});
+    }
 };
 
 template<typename Cls, int defValue = -1>


### PR DESCRIPTION
...so that instead of:

```
br.device.reset(new OpenRTB::Device);
```

it'll be possible to do:

```
br.device.emplace();
```

(And there'll be a lesser diff if I would someday prepare the patch (for the second time) to replace Optional by std::optional...)
