### PR TITLE
CounterAggregate not counting when cmp_xchg

### DIFF
--- a/service/stat_aggregator.h
+++ b/service/stat_aggregator.h
@@ -16,6 +16,7 @@
 #include <deque>
 #include <boost/scoped_ptr.hpp>
 
+#include <atomic>
 
 namespace Datacratic {
 
@@ -74,8 +75,8 @@ struct CounterAggregator : public StatAggregator {
     virtual std::vector<StatReading> read(const std::string & prefix);
 
 private:
-    Date start;    //< Date at which we last cleared the counter
-    double total;  //< total since we last added it up
+    Date start;                 //< Date at which we last cleared the counter
+    std::atomic<double> total;  //< total since we last added it up
 
     std::deque<double> totalsBuffer; //< Totals for the last n reads.
 
@@ -115,7 +116,7 @@ struct GaugeAggregator : public StatAggregator {
 private:
     Verbosity verbosity;
     Date start;  //< Date at which we last cleared the counter
-    ML::distribution<float> * volatile values;  //< List of added values
+    std::atomic<ML::distribution<float> *> values;
 };
 
 


### PR DESCRIPTION
- For some weird reason, the cmp_xchg is always returning 0 after the
  call. Changed the code to use an std::atomic<double>. Since the
  atomic<double> does not contains fetch_add operation, I am using
  compare_exchange_weak for the atomic operation.
- Removed the cmp_xchg as well from the GaugeAggregator. Now the
  stats_aggregator.h is using only std c++11 atomic operations

This problem might occur, because we are compiling rtbkit with gcc-4.8
