### PR TITLE
Fixes for gcc 4.6

### DIFF
--- a/service/nprobe.h
+++ b/service/nprobe.h
@@ -31,6 +31,16 @@
 namespace RTBKIT
 {
 
+#define GCC_VERSION (__GNUC__ * 10000       \
+                     + __GNUC_MINOR__ * 100 \
+                     + __GNUC_PATCHLEVEL__)
+
+#if GCC_VERSION >= 40700
+    typedef std::chrono::steady_clock clock_type;
+#else
+    typedef std::chrono::monotonic_clock clock_type;
+#endif
+
 typedef std::tuple<const char*,std::string,uint32_t> ProbeCtx;
 
 //// base template
@@ -42,7 +52,7 @@ struct Span
 {
     std::string              tag_ ;
     uint32_t                 id_, pid_;
-    std::chrono::monotonic_clock::time_point start_, end_;
+    clock_type::time_point start_, end_;
     Span(uint32_t id = 0, uint32_t pid = 0) : id_ (id), pid_(pid) {}
 };
 typedef std::function<void(const ProbeCtx&, const std::vector<Span>&)> SinkCb;
@@ -101,14 +111,14 @@ public:
         else
             sp.pid_ = 0;
         sp.id_ = ++std::get<0>(*spans_);
-        sp.start_ = std::chrono::monotonic_clock::now () ;
+        sp.start_ = clock_type::now () ;
         std::get<1>(*spans_).emplace (sp);
     }
 
     ~Trace ()
     {
         if (!probed_) return;
-        std::get<1>(*spans_).top().end_ = std::chrono::monotonic_clock::now () ;
+        std::get<1>(*spans_).top().end_ = clock_type::now () ;
         std::get<2>(*spans_).emplace_back (std::move(std::get<1>(*spans_).top()));
         std::get<1>(*spans_).pop() ;
         if (std::get<1>(*spans_).empty ())


### PR DESCRIPTION
Fixed two things in Trace class for gcc 4.6 :
- Replaced delegating constructor by an init function ;
- Removed the delete specifier for Span copy assignment operator since gcc 4.6 does not support std::move_if_noexcept and calls the copy assignment operator rather than the move operator when resizing.
