### PR TITLE
enable instantiation of NULLID Id instance when parsing a "null" value

### DIFF
--- a/types/json_parsing.h
+++ b/types/json_parsing.h
@@ -717,6 +717,13 @@ void parseJson(Id * output, Context & context)
         return;
     }
 
+    if (context.isNull()) {
+        context.expectNull();
+        *output = Id();
+        output->type = Id::NULLID;
+        return;
+    }
+
     throw ML::Exception("unhandled id conversion type");
 }
 


### PR DESCRIPTION
This patch enables support of "null" ids, and prevent an exception from being thrown when such a case is encountered.
