### PR TITLE
declare StructureDescription as value kind "STRUCTURE"

### DIFF
--- a/types/value_description.h
+++ b/types/value_description.h
@@ -531,7 +531,8 @@ struct StructureDescription
       public StructureDescriptionBase {
     StructureDescription(bool nullAccepted = false,
                          const std::string & structName = "")
-        : StructureDescriptionBase(&typeid(Struct), structName,
+        : ValueDescriptionT<Struct>(ValueKind::STRUCTURE),
+          StructureDescriptionBase(&typeid(Struct), structName,
                                    nullAccepted)
     {
     }


### PR DESCRIPTION
This construct StructureDescription explicitly as ValueKind::STRUCTURE elements, rather than the default ValueKind::ATOM type
