### PR TITLE
adjusted parse-/printIso8601 to accept an arbitrary number of fractional seconds

### DIFF
--- a/types/date.cc
+++ b/types/date.cc
@@ -5,6 +5,7 @@
 */
 
 #include "date.h"
+#include <cmath>
 #include <limits>
 #include "jml/arch/format.h"
 #include "soa/js/js_value.h"
@@ -301,7 +302,7 @@ printRfc2616() const
 
 std::string
 Date::
-printIso8601() const
+printIso8601(unsigned int fraction) const
 {
     if (!std::isfinite(secondsSinceEpoch_)) {
         if (std::isnan(secondsSinceEpoch_)) {
@@ -316,7 +317,7 @@ printIso8601() const
     string result = print("%Y-%m-%dT%H:%M:%S");
 
     double partial_seconds = fractionalSeconds();
-    string fractional = format("%.3fZ", partial_seconds);
+    string fractional = format("%.*fZ", fraction, partial_seconds);
 
     result.append(fractional, 1, -1);
 
@@ -1324,9 +1325,11 @@ expectTime()
     }
 
     if (match_literal('.')) {
-        int millis = expectFixedWidthInt(*this, 3, 3, 0, 999,
-                                         "bad milliseconds");
-        date.addSeconds(float(millis) / 1000);
+        size_t start = get_offset();
+        int millis = expect_int();
+        size_t end = get_offset();
+        double seconds = double(millis) / pow(10, end-start);
+        date.addSeconds(seconds);
     }
 
     if (eof()) {

--- a/types/date.h
+++ b/types/date.h
@@ -90,7 +90,7 @@ struct Date {
 
     std::string print(unsigned seconds_digits = 0) const;
     std::string print(const std::string & format) const;
-    std::string printIso8601() const;
+    std::string printIso8601(unsigned int fraction = 3) const;
     std::string printRfc2616() const;
     std::string printClassic() const;
 

--- a/types/testing/date_test.cc
+++ b/types/testing/date_test.cc
@@ -95,6 +95,44 @@ BOOST_AUTO_TEST_CASE(test_date_parse_iso8601_date_time)
         expected = "2012-Dec-20 14:57:57.187";
         BOOST_CHECK_EQUAL(date.print(3), expected);
     }
+
+    /* fractional seconds */
+    {
+        string dt = "2012-12-20T14:57:57.1+00:00";
+        date = Date::parseIso8601DateTime(dt);
+        expected = "2012-Dec-20 14:57:57.100000";
+        BOOST_CHECK_EQUAL(date.print(6), expected);
+
+        dt = "2012-12-20T14:57:57.12+00:00";
+        date = Date::parseIso8601DateTime(dt);
+        expected = "2012-Dec-20 14:57:57.120000";
+        BOOST_CHECK_EQUAL(date.print(6), expected);
+
+        dt = "2012-12-20T14:57:57.123+00:00";
+        date = Date::parseIso8601DateTime(dt);
+        expected = "2012-Dec-20 14:57:57.123000";
+        BOOST_CHECK_EQUAL(date.print(6), expected);
+
+        dt = "2012-12-20T14:57:57.1234+00:00";
+        date = Date::parseIso8601DateTime(dt);
+        expected = "2012-Dec-20 14:57:57.123400";
+        BOOST_CHECK_EQUAL(date.print(6), expected);
+
+        dt = "2012-12-20T14:57:57.12345+00:00";
+        date = Date::parseIso8601DateTime(dt);
+        expected = "2012-Dec-20 14:57:57.123450";
+        BOOST_CHECK_EQUAL(date.print(6), expected);
+
+        dt = "2012-12-20T14:57:57.123456+00:00";
+        date = Date::parseIso8601DateTime(dt);
+        expected = "2012-Dec-20 14:57:57.123456";
+        BOOST_CHECK_EQUAL(date.print(6), expected);
+
+        dt = "2012-12-20T14:57:57.1234567+00:00";
+        date = Date::parseIso8601DateTime(dt);
+        expected = "2012-Dec-20 14:57:57.1234567";
+        BOOST_CHECK_EQUAL(date.print(7), expected);
+    }
 }
 
 #if 0
@@ -428,6 +466,10 @@ BOOST_AUTO_TEST_CASE( test_printIso8601 )
 
     string expected = "2012-09-19T21:16:40.417Z";
     string result = testDate.printIso8601();
+    BOOST_CHECK_EQUAL(result, expected);
+
+    expected = "2012-09-19T21:16:40.416978Z";
+    result = testDate.printIso8601(6);
     BOOST_CHECK_EQUAL(result, expected);
 }
 


### PR DESCRIPTION
At first, I believed that iso8601 only accepted milliseconds precision, but that seems to actually be undefined, and we are using microsecond precision at many places. This change thus enables the parsing and the printing of fractions of a second at any precision.
