### PR TITLE
fixed Date throwing an exception when its value > LONG_LONG_MAX

### DIFF
--- a/types/date.cc
+++ b/types/date.cc
@@ -391,6 +391,13 @@ print(const std::string & format) const
     size_t buffer_size = format.size() + 1024;
     char buffer[buffer_size];
 
+    if (secondsSinceEpoch() > std::numeric_limits<time_t>::max()) {
+        return "Inf";
+    }
+    if (secondsSinceEpoch() < std::numeric_limits<time_t>::min()) {
+        return "-Inf";
+    }
+
     time_t t = secondsSinceEpoch();
     tm time;
 

--- a/types/testing/date_test.cc
+++ b/types/testing/date_test.cc
@@ -513,3 +513,15 @@ BOOST_AUTO_TEST_CASE( test_iso8601WeekStart )
     // memset(&tm, 0, sizeof(struct tm));
     // strptime(x.c_str(), fmt.c_str(), &tm);
 // }
+
+BOOST_AUTO_TEST_CASE( test_date_iostream_print )
+{
+    BOOST_CHECK_EQUAL(boost::lexical_cast<std::string>(Date::positiveInfinity()),
+                      "Inf");
+    BOOST_CHECK_EQUAL(boost::lexical_cast<std::string>(Date::negativeInfinity()),
+                      "-Inf");
+    BOOST_CHECK_EQUAL(boost::lexical_cast<std::string>(Date::notADate()),
+                      "NaD");
+    BOOST_CHECK_EQUAL(boost::lexical_cast<std::string>(Date::fromSecondsSinceEpoch((uint64_t)-1)),
+                      "Inf");
+}


### PR DESCRIPTION
This fixes the following exception when attempting to print a date:

```
too large for defined data type
-9223372036854775808
9.22337e+18
----------------- Exception thrown ------------------------
type: ML::Exception
pid: 26285; tid: 22586
what: problem with gmtime_r
stack:
00: 0x0x7f8bcde85e17 at __cxa_throw + 0x27 in build/x86_64/bin/libexception_hook.so + 0xe17build/x86_6
4/bin/libexception_hook.so(__cxa_throw+0x27) 0x7f8bcde85e17
01: 0x0x7f8bcbe2d8e7 at Datacratic::Date::print(std::string const&) const + 0x207 in build/x86_64/bin/
libtypes.so + 0x1f8e7build/x86_64/bin/libtypes.so(_ZNK10Datacratic4Date5printERKSs+0x207) [0x7f8bcbe2d
8e7]
02: 0x0x7f8bcbe2dd2c at Datacratic::Date::print(unsigned int) const + 0xac in build/x86_64/bin/libtype
s.so + 0x1fd2cbuild/x86_64/bin/libtypes.so(_ZNK10Datacratic4Date5printEj+0xac) 0x7f8bcbe2dd2c
03: 0x0x7f8bcbe2de27 at Datacratic::operator<<(std::ostream&, Datacratic::Date const&) + 0x17 in build
/x86_64/bin/libtypes.so + 0x1fe27build/x86_64/bin/libtypes.so(_ZN10DatacraticlsERSoRKNS_4DateE+0x17) [
0x7f8bcbe2de27]
```

Note that there is some loss in precision, in that dates that can't fit in 64 bits of seconds will come out as "Inf" when printed.
