### PR TITLE
added better error messages when an object field fails parsing

### DIFF
--- a/types/json_parsing.h
+++ b/types/json_parsing.h
@@ -144,6 +144,11 @@ struct JsonParsingContext {
     /** Handler for when we get an undexpected field. */
 
     virtual void exception(const std::string & message) = 0;
+
+    /** Return a string that gives the context of where the parsing is
+        at, for example line number and column.
+    */
+    virtual std::string getContext() const = 0;
     
     virtual int expectInt() = 0;
     virtual unsigned int expectUnsignedInt() = 0;
@@ -424,7 +429,12 @@ struct StreamingJsonParsingContext
 
     virtual void exception(const std::string & message)
     {
-        context->exception(message);
+        context->exception("at " + printPath() + ": " + message);
+    }
+
+    virtual std::string getContext() const
+    {
+        return context->where() + " at " + printPath();
     }
 
 #if 0
@@ -458,6 +468,11 @@ struct StructuredJsonParsingContext: public JsonParsingContext {
         throw ML::Exception("At path " + printPath() + ": " + message);
     }
     
+    virtual std::string getContext() const
+    {
+        return printPath();
+    }
+
     virtual int expectInt()
     {
         return current->asInt();


### PR DESCRIPTION
Includes the field path and context information when a JSON object fails to parse, which aids in debugging JSON parsing failures.
