### PR TITLE
S3 error handling

### DIFF
--- a/service/s3.cc
+++ b/service/s3.cc
@@ -287,7 +287,7 @@ performSync() const
             }
             if (responseBody.size() > 0) {
                 message += (string("body (") + to_string(responseBody.size())
-                            + " bytes):\n" + responseBody);
+                            + " bytes):\n" + responseBody + "\n");
             }
 
             /* log so-called "REST error"


### PR DESCRIPTION
This pull request does the following:
- allow retries only in the case of a recoverable error (HTTP status 500 or libCurl exception)
- perform retries with exponental backoff
- make number of retries configurable via "S3_RETRIES" env var
- style adjustments
