### PR TITLE
Move functions out of header in REST request binding (TRIVIAL)

### DIFF
--- a/service/rest_request_binding.cc
+++ b/service/rest_request_binding.cc
@@ -1,0 +1,87 @@
+/* rest_request_binding.cc                                         -*- C++ -*-
+   Jeremy Barnes, 21 May 2014
+   Copyright (c) 2014 Datacratic Inc.  All rights reserved.
+
+*/
+
+#include "rest_request_binding.h"
+
+namespace Datacratic {
+
+/** These functions turn an argument to the request binding into a function
+    that can generate the value required by the handler function.
+
+*/
+
+std::function<std::string
+              (const RestServiceEndpoint::ConnectionId & connection,
+               const RestRequest & request,
+               const RestRequestParsingContext & context)>
+createParameterExtractor(Json::Value & argHelp,
+                         const StringPayload & p, void *)
+{
+    Json::Value & v = argHelp["payload"];
+    v["description"] = p.description;
+
+    return [=] (const RestServiceEndpoint::ConnectionId & connection,
+                const RestRequest & request,
+                const RestRequestParsingContext & context)
+        {
+            return request.payload;
+        };
+}
+
+/** Pass the connection on */
+std::function<const RestServiceEndpoint::ConnectionId &
+                     (const RestServiceEndpoint::ConnectionId & connection,
+                      const RestRequest & request,
+                      const RestRequestParsingContext & context)>
+createParameterExtractor(Json::Value & argHelp,
+                         const PassConnectionId &, void *)
+{
+    return [] (const RestServiceEndpoint::ConnectionId & connection,
+                const RestRequest & request,
+                const RestRequestParsingContext & context)
+        -> const RestServiceEndpoint::ConnectionId &
+        {
+            return connection;
+        };
+}
+
+/** Pass the connection on */
+std::function<const RestRequestParsingContext &
+                     (const RestServiceEndpoint::ConnectionId & connection,
+                      const RestRequest & request,
+                      const RestRequestParsingContext & context)>
+createParameterExtractor(Json::Value & argHelp,
+                         const PassParsingContext &, void *)
+{
+    return [] (const RestServiceEndpoint::ConnectionId & connection,
+                const RestRequest & request,
+                const RestRequestParsingContext & context)
+        -> const RestRequestParsingContext &
+        {
+            return context;
+        };
+}
+
+/** Pass the connection on */
+std::function<const RestRequest &
+                     (const RestServiceEndpoint::ConnectionId & connection,
+                      const RestRequest & request,
+                      const RestRequestParsingContext & context)>
+createParameterExtractor(Json::Value & argHelp,
+                         const PassRequest &, void *)
+{
+    return [] (const RestServiceEndpoint::ConnectionId & connection,
+               const RestRequest & request,
+               const RestRequestParsingContext & context)
+        -> const RestRequest &
+        {
+            return request;
+        };
+}
+
+
+
+} // namespace Datacratic

--- a/service/rest_request_binding.h
+++ b/service/rest_request_binding.h
@@ -103,74 +103,36 @@ createParameterExtractor(Json::Value & argHelp, const T & p, void * = 0)
 }
 #endif
 
-inline static std::function<std::string
-                     (const RestServiceEndpoint::ConnectionId & connection,
-                      const RestRequest & request,
-                      const RestRequestParsingContext & context)>
-createParameterExtractor(Json::Value & argHelp,
-                         const StringPayload & p, void * = 0)
-{
-    Json::Value & v = argHelp["payload"];
-    v["description"] = p.description;
-
-    return [=] (const RestServiceEndpoint::ConnectionId & connection,
-                const RestRequest & request,
-                const RestRequestParsingContext & context)
-        {
-            return request.payload;
-        };
-}
-
-/** Pass the connection on */
-inline static std::function<const RestServiceEndpoint::ConnectionId &
-                     (const RestServiceEndpoint::ConnectionId & connection,
-                      const RestRequest & request,
-                      const RestRequestParsingContext & context)>
-createParameterExtractor(Json::Value & argHelp,
-                         const PassConnectionId &, void * = 0)
-{
-    return [] (const RestServiceEndpoint::ConnectionId & connection,
-                const RestRequest & request,
-                const RestRequestParsingContext & context)
-        -> const RestServiceEndpoint::ConnectionId &
-        {
-            return connection;
-        };
-}
-
-/** Pass the connection on */
-inline static std::function<const RestRequestParsingContext &
-                     (const RestServiceEndpoint::ConnectionId & connection,
-                      const RestRequest & request,
-                      const RestRequestParsingContext & context)>
-createParameterExtractor(Json::Value & argHelp,
-                         const PassParsingContext &, void * = 0)
-{
-    return [] (const RestServiceEndpoint::ConnectionId & connection,
-                const RestRequest & request,
-                const RestRequestParsingContext & context)
-        -> const RestRequestParsingContext &
-        {
-            return context;
-        };
-}
-
-/** Pass the connection on */
-inline static std::function<const RestRequest &
-                     (const RestServiceEndpoint::ConnectionId & connection,
-                      const RestRequest & request,
-                      const RestRequestParsingContext & context)>
-createParameterExtractor(Json::Value & argHelp,
-                         const PassRequest &, void * = 0)
-{
-    return [] (const RestServiceEndpoint::ConnectionId & connection,
+std::function<std::string
+              (const RestServiceEndpoint::ConnectionId & connection,
                const RestRequest & request,
-               const RestRequestParsingContext & context)
-        -> const RestRequest &
-        {
-            return request;
-        };
-}
+               const RestRequestParsingContext & context)>
+createParameterExtractor(Json::Value & argHelp,
+                         const StringPayload & p, void * = 0);
+
+/** Pass the connection on */
+std::function<const RestServiceEndpoint::ConnectionId &
+              (const RestServiceEndpoint::ConnectionId & connection,
+               const RestRequest & request,
+               const RestRequestParsingContext & context)>
+createParameterExtractor(Json::Value & argHelp,
+                         const PassConnectionId &, void * = 0);
+
+/** Pass the connection on */
+std::function<const RestRequestParsingContext &
+              (const RestServiceEndpoint::ConnectionId & connection,
+               const RestRequest & request,
+               const RestRequestParsingContext & context)>
+createParameterExtractor(Json::Value & argHelp,
+                         const PassParsingContext &, void * = 0);
+
+/** Pass the connection on */
+std::function<const RestRequest &
+              (const RestServiceEndpoint::ConnectionId & connection,
+               const RestRequest & request,
+               const RestRequestParsingContext & context)>
+createParameterExtractor(Json::Value & argHelp,
+                         const PassRequest &, void * = 0);
 
 /** Free function to be called in order to generate a parameter extractor
     for the given parameter.  See the CreateRestParameterGenerator class for more

--- a/service/service.mk
+++ b/service/service.mk
@@ -44,6 +44,7 @@ LIBSERVICES_SOURCES := \
 	http_named_endpoint.cc \
 	rest_proxy.cc \
 	rest_request_router.cc \
+	rest_request_binding.cc \
 	runner.cc \
 	sink.cc \
 	zookeeper.cc \


### PR DESCRIPTION
In order to reduce compile times, these functions are moved into the .cc file
