### PR TITLE
Add ability to turn off log categories by default (PLAT-564)

### DIFF
--- a/service/testing/logs_test.cc
+++ b/service/testing/logs_test.cc
@@ -24,12 +24,14 @@ BOOST_AUTO_TEST_CASE(blah)
 {
     Logging::Category d("d", "a");
     Logging::Category e("e", "d");
+    Logging::Category f("f", "d", false /* enabled */);
 
     BOOST_CHECK(a.isEnabled());
     BOOST_CHECK(b.isEnabled());
     BOOST_CHECK(c.isEnabled());
     BOOST_CHECK(d.isEnabled());
     BOOST_CHECK(e.isEnabled());
+    BOOST_CHECK(!f.isEnabled());
 
     BOOST_CHECK(!!a.getWriter());
     BOOST_CHECK(!!b.getWriter());


### PR DESCRIPTION
Adds an extra boolean parameter to the log category that allows it to be turned off by default, to support the 'recompile with verbose logging' use-case.  This could be combined at a later stage with the ability to modify logging via environment variables or a SHM segment and a signal.
