### PR TITLE
Allow REST Service Endpoint to work with chunked encoding (PLAT-562)

### DIFF
--- a/service/http_endpoint.cc
+++ b/service/http_endpoint.cc
@@ -363,10 +363,13 @@ putResponseOnWire(HttpResponse response,
         responseStr.append(response.contentType);
         responseStr.append("\r\n");
     }
-    responseStr.append("Content-Length: ");
-    responseStr.append(to_string(response.body.length()));
-    responseStr.append("\r\n");
-    responseStr.append("Connection: Keep-Alive\r\n");
+
+    if (response.sendBody) {
+        responseStr.append("Content-Length: ");
+        responseStr.append(to_string(response.body.length()));
+        responseStr.append("\r\n");
+        responseStr.append("Connection: Keep-Alive\r\n");
+    }
 
     for (auto & h: response.extraHeaders) {
         responseStr.append(h.first);

--- a/service/http_endpoint.h
+++ b/service/http_endpoint.h
@@ -37,7 +37,23 @@ struct HttpResponse {
           responseStatus(getResponseReasonPhrase(responseCode)),
           contentType(contentType),
           body(body),
-          extraHeaders(extraHeaders)
+          extraHeaders(extraHeaders),
+          sendBody(true)
+    {
+    }
+
+    /** Construct an HTTP response header only, with no body.  No content-
+        length will be inferred. */
+
+    HttpResponse(int responseCode,
+                 std::string contentType,
+                 std::vector<std::pair<std::string, std::string> > extraHeaders
+                     = std::vector<std::pair<std::string, std::string> >())
+        : responseCode(responseCode),
+          responseStatus(getResponseReasonPhrase(responseCode)),
+          contentType(contentType),
+          extraHeaders(extraHeaders),
+          sendBody(false)
     {
     }
 
@@ -49,7 +65,8 @@ struct HttpResponse {
           responseStatus(getResponseReasonPhrase(responseCode)),
           contentType("application/json"),
           body(boost::trim_copy(body.toString())),
-          extraHeaders(extraHeaders)
+          extraHeaders(extraHeaders),
+          sendBody(true)
     {
     }
 
@@ -58,6 +75,7 @@ struct HttpResponse {
     std::string contentType;
     std::string body;
     std::vector<std::pair<std::string, std::string> > extraHeaders;
+    bool sendBody;
 };
 
 

--- a/service/http_named_endpoint.h
+++ b/service/http_named_endpoint.h
@@ -79,6 +79,10 @@ struct HttpNamedEndpoint : public NamedEndpoint, public HttpEndpoint {
                           const std::string & body,
                           const std::string & contentType,
                           RestParams headers = RestParams());
+
+        void sendResponseHeader(int code,
+                                const std::string & contentType,
+                                RestParams headers = RestParams());
     };
 
     typedef std::function<void (RestConnectionHandler * connection,

--- a/service/rest_service_endpoint.cc
+++ b/service/rest_service_endpoint.cc
@@ -199,6 +199,66 @@ sendHttpResponse(int responseCode,
     itl->responseSent = true;
 }
 
+void
+RestServiceEndpoint::ConnectionId::
+sendHttpResponseHeader(int responseCode,
+                       const std::string & contentType,
+                       ssize_t contentLength,
+                       const RestParams & headers_) const
+{
+    if (itl->responseSent)
+        throw ML::Exception("response already sent");
+
+    if (!itl->http)
+        throw ML::Exception("sendHttpResponseHeader only works on HTTP connections");
+
+    if (itl->endpoint->logResponse)
+        itl->endpoint->logResponse(*this, responseCode, "", contentType);
+
+    RestParams headers = headers_;
+    if (contentLength == CHUNKED_ENCODING) {
+        itl->chunkedEncoding = true;
+        headers.push_back({"Transfer-Encoding", "chunked"});
+    }
+    else if (contentLength >= 0) {
+        headers.push_back({"Content-Length", to_string(contentLength) });
+    }
+    else {
+        itl->keepAlive = false;
+    }
+
+    itl->http->sendResponseHeader(responseCode, contentType, headers);
+}
+
+void
+RestServiceEndpoint::ConnectionId::
+sendPayload(const std::string & payload)
+{
+    if (itl->chunkedEncoding) {
+        if (payload.empty()) {
+            throw ML::Exception("Can't send empty chunk over a chunked connection");
+        }
+        string length = ML::format("%llx\r\n", (long long)payload.length());
+        itl->http->sendHttpChunk(payload, HttpConnectionHandler::NEXT_CONTINUE);
+    }
+    else itl->http->send(payload);
+}
+
+void
+RestServiceEndpoint::ConnectionId::
+finishResponse()
+{
+    if (itl->chunkedEncoding) {
+        itl->http->sendHttpChunk("", HttpConnectionHandler::NEXT_RECYCLE);
+    }
+    else if (!itl->keepAlive) {
+        itl->http->closeConnection();
+    }
+
+    itl->responseSent = true;
+}
+
+
 
 /*****************************************************************************/
 /* REST SERVICE ENDPOINT                                                     */


### PR DESCRIPTION
Allows a payload to be sent with the header and each chunk separately, and for the chunks to be encoded.  This is useful for when you want to "watch" something that has discrete events coming in with a long-running connection.
