### PR TITLE
expose the number of threads used for s3 upload (PLAT-563)

### DIFF
--- a/logger/cloud_output.cc
+++ b/logger/cloud_output.cc
@@ -122,11 +122,8 @@ open(const std::string & uri, bool append, bool disambiguate)
 
     currentUri = disambUri;
 
-    string compression = "";
-    int level = -1;
-    cloudStream.open(disambUri, std::ios_base::out |
-                     (append ? std::ios_base::app : std::ios::openmode()),
-                     compression, level, numThreads_);
+    cloudStream.open(disambUri, numThreads_, std::ios_base::out |
+                     (append ? std::ios_base::app : std::ios::openmode()));
 
     // Get the file name from the s3 uri. We want to preserve the path since
     // if we only get the filename we could overwrite files with the same name

--- a/logger/cloud_output.h
+++ b/logger/cloud_output.h
@@ -58,8 +58,8 @@ namespace Datacratic {
 struct CloudSink : public CompressingOutput::Sink {
     CloudSink(const std::string & uri ,
               bool append, bool disambiguate, std::string backupDir,
-              std::string bucket, std::string accessKeyId, std::string accessKey
-        );
+              std::string bucket, std::string accessKeyId, std::string accessKey,
+              unsigned int numThreads);
 
     virtual ~CloudSink();
 
@@ -79,7 +79,7 @@ struct CloudSink : public CompressingOutput::Sink {
     std::string bucket_;
     std::string accessKeyId_;
     std::string accessKey_;
-
+    unsigned int numThreads_;
     /// Current stream to the cloud (TM)
     ML::filter_ostream cloudStream;
     // we write to a temporary file on local disk which we delete when
@@ -113,6 +113,7 @@ struct CloudOutput : public NamedOutput {
 
     CloudOutput(std::string backupDir, std::string bucket, 
                 std::string accessKeyId, std::string accessKey,
+                unsigned int numThreads,
                 size_t ringBufferSize = 65536);
 
     virtual ~CloudOutput();
@@ -127,6 +128,7 @@ struct CloudOutput : public NamedOutput {
     std::string bucket_;
     std::string accessKeyId_;
     std::string accessKey_;
+    unsigned numThreads_;
     // note that this structure is only filled in a function that is guaranteed
     // to be called once
     static std::vector<boost::filesystem::path> filesToUpload_;
@@ -145,7 +147,8 @@ struct CloudOutput : public NamedOutput {
 struct RotatingCloudOutput : public RotatingOutputAdaptor {
 
     RotatingCloudOutput(std::string backupDir, std::string bucket, 
-                        std::string accessKeyId, std::string accessKey);
+                        std::string accessKeyId, std::string accessKey,
+                        unsigned int numThreads);
 
     virtual ~RotatingCloudOutput();
 
@@ -176,6 +179,7 @@ private:
     std::string bucket_;
     std::string accessKeyId_;
     std::string accessKey_;
+    unsigned int numThreads_;//number of threads to use for s3 upload per file
 };
 
 } // namespace Datacratic

--- a/service/s3.h
+++ b/service/s3.h
@@ -226,13 +226,15 @@ struct S3Api : public AwsApi {
     struct ObjectMetadata {
         ObjectMetadata()
             : redundancy(REDUNDANCY_DEFAULT),
-              serverSideEncryption(SSE_NONE)
+              serverSideEncryption(SSE_NONE),
+              numThreads(8)
         {
         }
 
         ObjectMetadata(const Redundancy & redundancy)
             : redundancy(redundancy),
-              serverSideEncryption(SSE_NONE)
+              serverSideEncryption(SSE_NONE),
+              numThreads(8)
         {
         }
 
@@ -245,6 +247,7 @@ struct S3Api : public AwsApi {
         std::string contentEncoding;
         std::map<std::string, std::string> metadata;
         std::string acl;
+        unsigned int numThreads;
     };
 
     /** Signed request that can be executed. */
@@ -425,7 +428,8 @@ struct S3Api : public AwsApi {
     std::auto_ptr<std::streambuf>
     streamingUpload(const std::string & bucket,
                     const std::string & object,
-                    const ObjectMetadata & md = ObjectMetadata()) const;
+                    const ObjectMetadata & md = ObjectMetadata(),
+                    unsigned int numThreads = 8) const;
 
     struct ObjectInfo : public FsObjectInfo {
         ObjectInfo()


### PR DESCRIPTION
The number of threads used for uploads to S3 is currently hard-coded to 8. This PR makes it possible to specify the number of threads