### PR TITLE
Carbon dump interval is now configurable and dissociated from the sampling rate.

### DIFF
--- a/service/carbon_connector.cc
+++ b/service/carbon_connector.cc
@@ -262,50 +262,49 @@ void
 MultiAggregator::
 runDumpingThread()
 {
-    Date nextDump = Date::now().plusSeconds(dumpInterval);
+    auto calcNextDump = [=] {
+        Date next = Date::now().plusSeconds(dumpInterval);
+        if (dumpInterval <= 1.0) return next;
+
+        size_t seconds = next.quantize(1).secondsSinceEpoch();
+        seconds -= seconds % size_t(dumpInterval);
+        seconds += dumpInterval / 2;
+        return Date::fromSecondsSinceEpoch(seconds);
+    };
+
+    Date nextDump = calcNextDump();
 
     for (;;) {
         std::unique_lock<std::mutex> lock(m);
 
-        while ((dumpInterval == 0.0 || Date::now() < nextDump)
-               && !doShutdown && !doDump)
-            cond.wait_until(lock, nextDump.toStd());
-        
-        if (doShutdown)
+        Date now = Date::now();
+        Date nextWakeup = now.plusSeconds(1.0);
+        if (cond.wait_until(lock, nextWakeup.toStd(), [&] { return doShutdown.load(); }))
             break;
-
-        ExcAssert((dumpInterval != 0.0 && Date::now() >= nextDump) || doDump);
-        
-        doDump = false;
 
         // Get the read lock to extract a list of stats to dump
         vector<Stats::iterator> toDump;
-
         {
             std::unique_lock<Lock> guard(this->lock);
             toDump.reserve(stats.size());
-            for (auto it = stats.begin(), end = stats.end();
-                 it != end;  ++it)
+            for (auto it = stats.begin(), end = stats.end(); it != end;  ++it)
                 toDump.push_back(it);
-            //std::copy(stats.begin(), stats.end(), back_inserter(toDump));
         }
 
-        std::vector<std::string> toWrite;
+        bool dumpNow = doDump.exchange(false) || now >= nextDump;
+        if (dumpNow) nextDump = calcNextDump();
 
-        // Now dump them without the lock held
-        for (auto it = toDump.begin(), end = toDump.end();
-             it != end;  ++it) {
+        // Now dump them without the lock held. Note that we still need to call
+        // read every second even if we're not flushing to carbon.
+        for (auto it = toDump.begin(), end = toDump.end(); it != end;  ++it) {
 
             try {
-                //cerr << "doStat(" << (*it)->first << ")" << endl;
-                doStat((*it)->second->read((*it)->first));
+                auto stat = (*it)->second->read((*it)->first);
+                if (dumpNow) doStat(std::move(stat));
             } catch (const std::exception & exc) {
                 cerr << "error writing stat: " << exc.what() << endl;
             }
         }
-
-        while (nextDump < Date::now() && dumpInterval != 0.0)
-            nextDump.addSeconds(dumpInterval);
     }
 }
 
@@ -322,17 +321,19 @@ CarbonConnector()
 CarbonConnector::
 CarbonConnector(const std::string & carbonAddr,
                 const std::string & path,
+                double dumpInterval,
                 std::function<void ()> onStop)
 {
-    open(carbonAddr, path, onStop);
+    open(carbonAddr, path, dumpInterval, onStop);
 }
 
 CarbonConnector::
 CarbonConnector(const std::vector<std::string> & carbonAddrs,
                 const std::string & path,
+                double dumpInterval,
                 std::function<void ()> onStop)
 {
-    open(carbonAddrs, path, onStop);
+    open(carbonAddrs, path,dumpInterval,  onStop);
 }
 
 CarbonConnector::
@@ -345,15 +346,17 @@ void
 CarbonConnector::
 open(const std::string & carbonAddr,
      const std::string & path,
+     double dumpInterval,
      std::function<void ()> onStop)
 {
-    return open(vector<string>({carbonAddr}), path, onStop);
+    return open(vector<string>({carbonAddr}), path, dumpInterval, onStop);
 }
 
 void
 CarbonConnector::
 open(const std::vector<std::string> & carbonAddrs,
      const std::string & path,
+     double dumpInterval,
      std::function<void ()> onStop)
 {
     stop();
@@ -377,7 +380,7 @@ open(const std::vector<std::string> & carbonAddrs,
 
     this->onPostShutdown = std::bind(&CarbonConnector::doShutdown, this);
 
-    MultiAggregator::open(path, OutputFn(), 1.0, onStop);
+    MultiAggregator::open(path, OutputFn(), dumpInterval, onStop);
 }
 
 void

--- a/service/carbon_connector.h
+++ b/service/carbon_connector.h
@@ -16,6 +16,7 @@
 #include <map>
 #include <memory>
 #include <thread>
+#include <atomic>
 #include <condition_variable>
 #include <boost/thread.hpp>
 
@@ -152,8 +153,8 @@ private:
 
     std::condition_variable cond;  // to wake up dumping thread
     std::mutex m;
-    bool doShutdown;                 // thread woken up to shutdown
-    bool doDump;                     // thread woken up to dump
+    std::atomic<bool> doShutdown;                 // thread woken up to shutdown
+    std::atomic<bool> doDump;                     // thread woken up to dump
 
     /** How many seconds to wait before we dump.  If set to zero, dumping
         is only done on demand.
@@ -175,11 +176,13 @@ struct CarbonConnector : public MultiAggregator {
 
     CarbonConnector(const std::string & carbonAddr,
                     const std::string & path,
+                    double dumpInterval = 1.0,
                     std::function<void ()> onStop
                         = std::function<void ()>());
 
     CarbonConnector(const std::vector<std::string> & carbonAddrs,
                     const std::string & path,
+                    double dumpInterval = 1.0,
                     std::function<void ()> onStop
                         = std::function<void ()>());
 
@@ -187,11 +190,13 @@ struct CarbonConnector : public MultiAggregator {
 
     void open(const std::string & carbonAddr,
               const std::string & path,
+              double dumpInterval = 1.0,
               std::function<void ()> onStop
                   = std::function<void ()>());
 
     void open(const std::vector<std::string> & carbonAddrs,
               const std::string & path,
+              double dumpInterval = 1.0,
               std::function<void ()> onStop
                   = std::function<void ()>());
 

--- a/service/js/opstats_js.cc
+++ b/service/js/opstats_js.cc
@@ -129,11 +129,13 @@ struct CarbonConnectorJS
                 getShared(args)->open(getArg<vector<string> >
                                       (args, 0, "carbonAddr"),
                                       getArg(args, 1, "statsPath"),
+                                      getArg(args, 2, "dumpInterval"),
                                       cleanup);
             }
             else {
                 getShared(args)->open(getArg<string>(args, 0, "carbonAddr"),
                                       getArg(args, 1, "statsPath"),
+                                      getArg(args, 2, "dumpInterval"),
                                       cleanup);
             }
             

--- a/service/service_base.cc
+++ b/service/service_base.cc
@@ -105,15 +105,17 @@ CarbonEventService(std::shared_ptr<CarbonConnector> conn) :
 
 CarbonEventService::
 CarbonEventService(const std::string & carbonAddress,
-                   const std::string & prefix)
-    : connector(new CarbonConnector(carbonAddress, prefix))
+                   const std::string & prefix,
+                   double dumpInterval)
+    : connector(new CarbonConnector(carbonAddress, prefix, dumpInterval))
 {
 }
 
 CarbonEventService::
 CarbonEventService(const std::vector<std::string> & carbonAddresses,
-                   const std::string & prefix)
-    : connector(new CarbonConnector(carbonAddresses, prefix))
+                   const std::string & prefix,
+                   double dumpInterval)
+    : connector(new CarbonConnector(carbonAddresses, prefix, dumpInterval))
 {
 }
 
@@ -442,17 +444,19 @@ ServiceProxies()
 void
 ServiceProxies::
 logToCarbon(const std::string & carbonConnection,
-            const std::string & prefix)
+            const std::string & prefix,
+            double dumpInterval)
 {
-    events.reset(new CarbonEventService(carbonConnection, prefix));
+    events.reset(new CarbonEventService(carbonConnection, prefix, dumpInterval));
 }
 
 void
 ServiceProxies::
 logToCarbon(const std::vector<std::string> & carbonConnections,
-            const std::string & prefix)
+            const std::string & prefix,
+            double dumpInterval)
 {
-    events.reset(new CarbonEventService(carbonConnections, prefix));
+    events.reset(new CarbonEventService(carbonConnections, prefix, dumpInterval));
 }
 
 void
@@ -598,7 +602,9 @@ bootstrap(const Json::Value& config)
         }
         else uris.push_back(entry.asString());
 
-        logToCarbon(uris, install);
+        double dumpInterval = config.get("carbon-dump-interval", 1.0).asDouble();
+
+        logToCarbon(uris, install, dumpInterval);
     }
 
     if (config.isMember("zookeeper-uri"))

--- a/service/service_base.h
+++ b/service/service_base.h
@@ -87,9 +87,11 @@ struct CarbonEventService : public EventService {
 
     CarbonEventService(std::shared_ptr<CarbonConnector> conn);
     CarbonEventService(const std::string & connection,
-                       const std::string & prefix = "");
+                       const std::string & prefix = "",
+                       double dumpInterval = 1.0);
     CarbonEventService(const std::vector<std::string> & connections,
-                       const std::string & prefix = "");
+                       const std::string & prefix = "",
+                       double dumpInterval = 1.0);
 
     virtual void onEvent(const std::string & name,
                          const char * event,
@@ -407,9 +409,11 @@ struct ServiceProxies {
 
     void logToCarbon(std::shared_ptr<CarbonConnector> conn);
     void logToCarbon(const std::string & carbonConnection,
-                     const std::string & prefix = "");
+                     const std::string & prefix = "",
+                     double dumpInterval = 1.0);
     void logToCarbon(const std::vector<std::string> & carbonConnections,
-                     const std::string & prefix = "");
+                     const std::string & prefix = "",
+                     double dumpInterval = 1.0);
 
     void useZookeeper(std::string url = "localhost:2181",
                       std::string prefix = "CWD",


### PR DESCRIPTION
If the carbon retention rate is set at 10 sec then we send 9 updates which are simply discarded by carbon. This is fine until we add an aggregator in front of carbon which will end up summing all 10 updates before sending them to carbon which will result in values 10 times higher then they should be.

This patch starts by dissociating the sampling rate of the metrics from the dump interval. The reason for this is that the metrics need to be read every second so that the final count is per second and not per 10 second. 

We then calculate a dump time which will fall in the middle of the carbon dump window. This reduces the risk of not having a dump within a window due to timer drag.

Finally we expose the dump interval as a configuration parameter in the bootstrap.json so that we can leave the 1.0 dumpInterval by default. This is required to maintain the public interface such that the open-source community will not have to modify anything when deploying this new release.
