### PR TITLE
Make HttpNamedEndpoint keep shared pointer to connection

### DIFF
--- a/service/http_named_endpoint.h
+++ b/service/http_named_endpoint.h
@@ -61,6 +61,7 @@ struct HttpNamedEndpoint : public NamedEndpoint, public HttpEndpoint {
         RestConnectionHandler(HttpNamedEndpoint * endpoint);
 
         HttpNamedEndpoint * endpoint;
+        std::weak_ptr<RestConnectionHandler> sharedThis;
 
         virtual void
         handleHttpPayload(const HttpHeader & header,
@@ -85,7 +86,7 @@ struct HttpNamedEndpoint : public NamedEndpoint, public HttpEndpoint {
                                 RestParams headers = RestParams());
     };
 
-    typedef std::function<void (RestConnectionHandler * connection,
+    typedef std::function<void (std::shared_ptr<RestConnectionHandler> connection,
                                 const HttpHeader & header,
                                 const std::string & payload)> OnRequest;
 

--- a/service/rest_service_endpoint.cc
+++ b/service/rest_service_endpoint.cc
@@ -326,7 +326,7 @@ init(std::shared_ptr<ConfigurationService> config,
     zmqEndpoint.messageHandler = zmqHandler;
         
     httpEndpoint.onRequest
-        = [=] (HttpNamedEndpoint::RestConnectionHandler * connection,
+        = [=] (std::shared_ptr<HttpNamedEndpoint::RestConnectionHandler> connection,
                const HttpHeader & header,
                const std::string & payload)
         {

--- a/service/rest_service_endpoint.h
+++ b/service/rest_service_endpoint.h
@@ -97,7 +97,7 @@ struct RestServiceEndpoint: public MessageLoop {
         }
 
         /// Initialize for http
-        ConnectionId(HttpNamedEndpoint::RestConnectionHandler * http,
+        ConnectionId(std::shared_ptr<HttpNamedEndpoint::RestConnectionHandler> http,
                      const std::string & requestId,
                      RestServiceEndpoint * endpoint)
             : itl(new Itl(http, requestId, endpoint))
@@ -105,7 +105,7 @@ struct RestServiceEndpoint: public MessageLoop {
         }
 
         struct Itl {
-            Itl(HttpNamedEndpoint::RestConnectionHandler * http,
+            Itl(std::shared_ptr<HttpNamedEndpoint::RestConnectionHandler> http,
                 const std::string & requestId,
                 RestServiceEndpoint * endpoint)
                 : requestId(requestId),
@@ -140,7 +140,7 @@ struct RestServiceEndpoint: public MessageLoop {
 
             std::string zmqAddress;
             std::string requestId;
-            HttpNamedEndpoint::RestConnectionHandler * http;
+            std::shared_ptr<HttpNamedEndpoint::RestConnectionHandler> http;
             RestServiceEndpoint * endpoint;
             bool responseSent;
             Date startDate;


### PR DESCRIPTION
This makes it possible to avoid segmentation faults in the case where the remote end drops the connection.
Previously it would lead to the connection object being deleted and a dangling pointer.

Mostly relevant to long-running connections that are handled asynchronously.  In the synchronous case the
connection is locked for the duration and recycled afterwards, so it can't cause a problem.
