### PR TITLE
More flexibility in handling signal errors in Runner (TRIVIAL)

### DIFF
--- a/service/runner.cc
+++ b/service/runner.cc
@@ -465,25 +465,33 @@ run(const vector<string> & command,
     }
 }
 
-void
+bool
 Runner::
-kill(int signum) const
+kill(int signum, bool mustSucceed) const
 {
-    if (childPid_ <= 0)
-        throw ML::Exception("subprocess not available");
+    if (childPid_ <= 0) {
+        if (mustSucceed)
+            throw ML::Exception("subprocess not available");
+        else return false;
+    }
 
     ::kill(-childPid_, signum);
     waitTermination();
+    return true;
 }
 
-void
+bool
 Runner::
-signal(int signum)
+signal(int signum, bool mustSucceed)
 {
-    if (childPid_ <= 0)
-        throw ML::Exception("subprocess not available");
-
+    if (childPid_ <= 0) {
+        if (mustSucceed)
+            throw ML::Exception("subprocess not available");
+        else return false;
+    }
+    
     ::kill(childPid_, signum);
+    return true;
 }
 
 bool

--- a/service/runner.h
+++ b/service/runner.h
@@ -114,11 +114,23 @@ struct Runner: public Epoller {
              const std::shared_ptr<InputSink> & stdErrSink = nullptr);
 
     /** Kill the subprocess with the given signal, then wait for it to
-        terminate. */
-    void kill(int signal = SIGTERM) const;
+        terminate.
 
-    /** Send the given signal, but don't wait for it to terminate. */
-    void signal(int signum);
+        If mustSucceed = true, then an exception will be thrown if there
+        is no process.
+
+        Returns whether or not the call succeeded.
+    */
+    bool kill(int signal = SIGTERM, bool mustSucceed = true) const;
+
+    /** Send the given signal, but don't wait for it to terminate.
+
+        If mustSucceed = true, then an exception will be thrown if there
+        is no process.
+
+        Returns whether or not the call succeeded.
+    */
+    bool signal(int signum, bool mustSucceed = true);
 
     /** Synchronous wait for the subprocess to start.  Returns true if the
         process started, or false if it wasn't able to start.


### PR DESCRIPTION
This change adds a mustSucceed flag to the kill() and signal() functions in Runner, which
allows them to be called unconditionally.  This is especially useful in shutdowns, where we
don't want an exception if we tried to stop it but it was already stopped.  The default
behaviour remains the same: throw an exception.  They will also return whether they
succeded or not.

TRIVIAL because semantics of any existing calls have not changed.
