### PR TITLE
Fixed inconsistency in TypedMessageSink class. push function now uses Ri...

### DIFF
--- a/logger/logger.cc
+++ b/logger/logger.cc
@@ -356,7 +356,7 @@ replay(const std::string & filename, ssize_t maxEvents)
         string line;
         getline(stream, line);
         atomic_add(messagesSent, 1);
-        messages.push({ line });
+        messages.push(std::vector<std::string> { line });
     }
 
     cerr << "replay: sent " << messagesSent << " done: "

--- a/logger/logger.h
+++ b/logger/logger.h
@@ -143,25 +143,28 @@ struct Logger {
         be converted to a string and logged like that.
     */
     template<typename... Args>
-    void operator () (const std::string & channel, Args... args)
+    void operator () (const std::string & channel, Args&&... args)
     {
-        logMessage(channel, args...);
+        logMessage(channel, std::forward<Args>(args)...);
     }
 
     template<typename... Args>
-    void logMessage(const std::string & channel, Args... args)
+    void logMessage(const std::string & channel, Args&&... args)
     {
         if (!outputs) return;
         ML::atomic_add(messagesSent, 1);
-        messages.push({ channel, Date::now().print(5), args... });
+        messages.push(
+           std::vector<std::string>{ channel, Date::now().print(5),
+                         std::forward<Args>(args)... });
     }
 
     template<typename... Args>
-    void logMessageNoTimestamp(const std::string & channel, Args... args)
+    void logMessageNoTimestamp(const std::string & channel, Args&&... args)
     {
         if (!outputs) return;
         ML::atomic_add(messagesSent, 1);
-        messages.push({ channel, args... });
+        messages.push(
+             std::vector<std::string>{ channel, std::forward<Args>(args)... });
     }
 
     void logMessageNoTimestamp(const std::vector<std::string> & message)

--- a/service/typed_message_channel.h
+++ b/service/typed_message_channel.h
@@ -33,23 +33,17 @@ struct TypedMessageSink: public AsyncEventSource {
 
     std::function<void (Message && message)> onEvent;
 
-    void push(const Message & message)
+    template<typename MessageT>
+    void push(MessageT&& message)
     {
-        if (buf.tryPush(message))
-            wakeup.signal();
-        else
-            throw ML::Exception("the message queue is full");
-    }
-
-    void push(Message && message)
-    {
-        buf.push(message);
+        buf.push(std::forward<MessageT>(message));
         wakeup.signal();
     }
 
-    bool tryPush(Message && message)
+    template<typename MessageT>
+    bool tryPush(MessageT&& message)
     {
-        bool pushed = buf.tryPush(message);
+        bool pushed = buf.tryPush(std::forward<MessageT>(message));
         if (pushed)
             wakeup.signal();
 


### PR DESCRIPTION
...ngBuffer::push. Also fixed perfect forwarding in the logger

This PR reverts back changes made to TypedMessageSink::push function. push is now using RingBuffer::push. This PR also allows tryPush to be called with an lvalue reference (via a universal reference).

I had to adapt some code in the logger to get it to compile and I also took advantage of the situation to enable perfect forwarding in the logger code.
