### PR TITLE
Simplified buggy gcc-specific js exception handling code.

### DIFF
--- a/js/js_utils.cc
+++ b/js/js_utils.cc
@@ -12,6 +12,7 @@
 #include "jml/arch/exception_internals.h"
 #include "jml/arch/backtrace.h"
 #include "jml/utils/string_functions.h"
+#include "jml/compiler/compiler.h"
 
 using namespace std;
 using namespace v8;
@@ -131,7 +132,7 @@ translateCurrentException()
     catch(const std::exception& ex) {
         return mapException(ex);
     }
-    catch(...) {
+    JML_CATCH_ALL {
         std::string msg = "unknown exception type";
         auto error = v8::Exception::Error(v8::String::New(msg.c_str()));
         return v8::ThrowException(injectBacktrace(error));


### PR DESCRIPTION
Fixes an issue whereby the JS wrappers are segfaulting when trying to handle exceptions. 

The old code relied on a bunch of gcc specific hidden interfaces that are not documented. After a couple hours of debugging assembly and ready through the libstdc++ source code, it seems like the __do_catch vtable entry for the std::type_info entry JSPassException is 0 which leads to a jump at address zero hence the segfault. 

I don't think it's worth investing more time into that code when there's a simple standard compliant way of handling the exceptions which doesn't segfault. Note that the new version is not 100% compatible with the old version since the catch(...) clause has no way of accessing the type_info object of the exception and I can't extract the type name for the error message.
