### PR TITLE
PLAT-771: Fix for double encoding for space in path

### DIFF
--- a/service/s3.cc
+++ b/service/s3.cc
@@ -79,11 +79,11 @@ struct S3UrlFsHandler : public UrlFsHandler {
         auto api = getS3ApiForBucket(bucket);
         auto bucketPath = S3Api::parseUri(url.original);
         if (throwException) {
-            api->eraseObject(bucket, bucketPath.second);
+            api->eraseObject(bucket, "/" + bucketPath.second);
             return true;
         }
         else { 
-            return api->tryEraseObject(bucket, bucketPath.second);
+            return api->tryEraseObject(bucket, "/" + bucketPath.second);
         }
     }
 


### PR DESCRIPTION
The call to url.path() already performs an encoding for spaces. When we call getObjectInfo s3EscapeResource performs an additional encoding which results in  doubly encoded spaces.
This fix makes sure that we use the original path when calling getObjectInfo.
