### PR TITLE
Child now receive a SIGTERM when the launcher dies

### DIFF
--- a/launcher/launcher.h
+++ b/launcher/launcher.h
@@ -217,7 +217,7 @@ struct Launcher
                 signal(SIGTERM, SIG_DFL);
                 signal(SIGKILL, SIG_DFL);
 
-                int res = prctl(PR_SET_PDEATHSIG, SIGHUP);
+                int res = prctl(PR_SET_PDEATHSIG, SIGTERM);
                 if(res == -1) {
                     THROW(launcherError) << "prctl failed errno=" << errno << std::endl;
                 }


### PR DESCRIPTION
This is mostly philosophical at this point since we fixed the first program that caught/ignored SIGHUP last week.

But nonetheless, it is much clearer to send a SIGTERM if we want the child program to exit. (and we really do want it to exit, otherwise the launcher will launch a second copy of it and chaos will follow.)
