### PR TITLE
Enabled ID_HASH_AS_STRING macro to provide consistency of type-independa...

### DIFF
--- a/types/id.cc
+++ b/types/id.cc
@@ -490,6 +490,10 @@ uint64_t
 Id::
 complexHash() const
 {
+#if ID_HASH_AS_STRING
+    std::string converted = toString();
+    return CityHash64(converted.c_str(), converted.size());
+#else
     if (type == STR)
         return CityHash64(str, len);
     else if (type == COMPOUND2) {
@@ -499,6 +503,7 @@ complexHash() const
     //else if (type == CUSTOM)
     //    return controlFn(CF_HASH, data);
     else throw ML::Exception("unknown Id type");
+#endif
 }
 
 void

--- a/types/id.h
+++ b/types/id.h
@@ -204,8 +204,14 @@ struct Id {
     uint64_t hash() const
     {
         if (type == NONE || type == NULLID) return 0;
+#if ID_HASH_AS_STRING
+        if (type == STR)
+            return CityHash64(str, len);
+        return complexHash();
+#else
         if (JML_UNLIKELY(type >= STR)) return complexHash();
         return Hash128to64(std::make_pair(val1, val2));
+#endif
     }
 
     bool complexEqual(const Id & other) const;

--- a/types/testing/id_test.cc
+++ b/types/testing/id_test.cc
@@ -329,3 +329,27 @@ BOOST_AUTO_TEST_CASE( test_compound_id )
 {
     Id id(Id("hello"), Id("world"));
 }
+
+#if ID_HASH_AS_STRING
+BOOST_AUTO_TEST_CASE( test_hash_as_string )
+{
+    /* COMPOUND */
+    {
+        Id typical(string("hello:big:world"), Id::STR);
+        Id id(Id("hello"), Id("big:world"));
+        BOOST_CHECK_EQUAL(typical.hash(), id.hash());
+    }
+
+    /* BIGDEC */
+    {
+        Id typical(string("12345678"), Id::STR);
+        BOOST_CHECK_EQUAL(typical.type, Id::STR);
+        Id id(12345678);
+        BOOST_CHECK_EQUAL(typical.hash(), id.hash());
+
+        id = Id("12345678");
+        BOOST_CHECK_EQUAL(id.type, Id::BIGDEC);
+        BOOST_CHECK_EQUAL(typical.hash(), id.hash());
+    }
+}
+#endif


### PR DESCRIPTION
...nt hash values for Id