### PR TITLE
Fix id -> uuid parser

### DIFF
--- a/types/id.cc
+++ b/types/id.cc
@@ -157,6 +157,12 @@ parse(const char * value, size_t len, Type type)
                 unsigned long long val = 0;
                 for (unsigned i = start;  i != start + len;  ++i) {
                     int c = p[i];
+                    if (c >= 65 && c <= 70) {
+                        // capital Hex must not parse
+                        failed = true;
+                        return val;
+                        continue;
+                    }
                     int v = hexToDec(c);
                     if (v == -1) {
                         failed = true;

--- a/types/id.cc
+++ b/types/id.cc
@@ -157,7 +157,7 @@ parse(const char * value, size_t len, Type type)
                 unsigned long long val = 0;
                 for (unsigned i = start;  i != start + len;  ++i) {
                     int c = p[i];
-                    if (c >= 65 && c <= 70) {
+                    if (c >= 'A' && c <= 'F') {
                         // capital Hex must not parse
                         failed = true;
                         return val;

--- a/types/id.cc
+++ b/types/id.cc
@@ -161,7 +161,6 @@ parse(const char * value, size_t len, Type type)
                         // capital Hex must not parse
                         failed = true;
                         return val;
-                        continue;
                     }
                     int v = hexToDec(c);
                     if (v == -1) {

--- a/types/testing/id_test.cc
+++ b/types/testing/id_test.cc
@@ -56,6 +56,13 @@ BOOST_AUTO_TEST_CASE( test_uuid_id )
     BOOST_CHECK_EQUAL(id.type, Id::UUID);
     BOOST_CHECK_EQUAL(id.toString(), uuid);
     checkSerializeReconstitute(id);
+
+    // Almost uuid, caps are not allowed so it's a string
+    string notUuid = "0828398C-5965-11E0-84C8-0026B937C8E1";
+    id = Id(notUuid);
+    BOOST_CHECK_EQUAL(id.type, Id::STR);
+    BOOST_CHECK_EQUAL(id.toString(), notUuid);
+    checkSerializeReconstitute(id);
 }
 
 BOOST_AUTO_TEST_CASE( test_goog64_id )


### PR DESCRIPTION
@jeremybarnes This is potentially dangerous. W/o this fix, it's an issue because parsing uuids containing upper cases dumped them with lower cases.

@wsourdeau Review too please.