### PR TITLE
PLAT-632: enable endpoint to go to sleep

### DIFF
--- a/service/endpoint.cc
+++ b/service/endpoint.cc
@@ -44,7 +44,7 @@ EndpointBase(const std::string & name)
       name_(name),
       threadsActive_(0),
       numTransports(0), shutdown_(false), disallowTimers_(false),
-      realTimePolling_(false)
+      pollingMode_(DEFAULT_POLLING)
 {
     Epoller::init(16384);
     auto wakeupData = make_shared<EpollData>(EpollData::EpollDataType::WAKEUP,
@@ -60,6 +60,16 @@ EndpointBase::
 ~EndpointBase()
 {
     shutdown();
+}
+
+void
+EndpointBase::
+setPollingMode(enum PollingMode mode)
+{
+    pollingMode_ = mode;
+
+    int timeout = modePollTimeout(mode);
+    setPollTimeout(timeout);
 }
 
 void
@@ -497,17 +507,41 @@ runEventThread(int threadNum, int numThreads)
 {
     prctl(PR_SET_NAME,"EptCtrl",0,0,0);
 
+    ML::atomic_inc(threadsActive_);
+    futex_wake(threadsActive_);
+    //cerr << "threadsActive_ " << threadsActive_ << endl;
+
+    while (!shutdown_) {
+        switch (pollingMode_) {
+        case DEFAULT_POLLING:
+            doDefaultPolling(threadNum, numThreads);
+            break;
+        case REALTIME_POLLING:
+            doRealtimePolling(threadNum, numThreads);
+            break;
+        case SLEEP_POLLING:
+            doSleepPolling(threadNum, numThreads);
+            break;
+        default:
+            throw ML::Exception("unhandled polling mode");
+        }
+    }
+
+    // cerr << "thread shutting down" << endl;
+
+    ML::atomic_dec(threadsActive_);
+    futex_wake(threadsActive_);
+}
+
+void
+EndpointBase::
+doDefaultPolling(int threadNum, int numThreads)
+{
     bool debug = false;
     //debug = name() == "Backchannel";
     //debug = threadNum == 7;
 
     ML::Duty_Cycle_Timer duty;
-
-    Date lastCheck = Date::now();
-
-    ML::atomic_inc(threadsActive_);
-    futex_wake(threadsActive_);
-    //cerr << "threadsActive_ " << threadsActive_ << endl;
 
     Epoller::OnEvent beforeSleep = [&] ()
         {
@@ -518,7 +552,6 @@ runEventThread(int threadNum, int numThreads)
         {
             duty.notifyAfterSleep();
         };
-
 
     // Where does my timeslice start?
     double timesliceUs = 1000.0 / numThreads;
@@ -536,37 +569,10 @@ runEventThread(int threadNum, int numThreads)
         lock.release();
     }
 
+    Date lastCheck = Date::now();
     // bool forceInSlice = false;
 
-    bool wasBusy = false;
-    Date sleepStart = Date::now();
-
-
     while (!shutdown_) {
-
-        // Busy loop polling which reduces the latency jitter caused by the
-        // fancy polling scheme below. Should eventually be replaced something a
-        // little less CPU intensive.
-        if (realTimePolling_) {
-
-            Date beforePoll = Date::now();
-            bool isBusy = handleEvents(0, 4, handleEvent) > 0;
-
-            // This ensures that our load sampling mechanism is still somewhat
-            // meaningfull even though we never sleep.
-            if (wasBusy != isBusy) {
-
-                if (wasBusy && !isBusy) sleepStart = beforePoll;
-
-                // We don't want to include the time we spent doing stuff.
-                else totalSleepTime[threadNum] += beforePoll - sleepStart;
-
-                wasBusy = isBusy;
-            }
-
-            continue;
-        }
-
         Date now = Date::now();
         
         if (now.secondsSince(lastCheck) > 1.0 && debug) {
@@ -647,11 +653,49 @@ runEventThread(int threadNum, int numThreads)
             }
         }
     }
+}
 
-    // cerr << "thread shutting down" << endl;
+void
+EndpointBase::
+doRealtimePolling(int threadNum, int numThreads)
+{
+    bool wasBusy = false;
+    Date sleepStart = Date::now();
 
-    ML::atomic_dec(threadsActive_);
-    futex_wake(threadsActive_);
+    while (!shutdown_) {
+        // Busy loop polling which reduces the latency jitter caused by
+        // the fancy polling scheme below. Should eventually be replaced
+        // something a little less CPU intensive.
+        Date beforePoll = Date::now();
+        bool isBusy = handleEvents(0, 4, handleEvent) > 0;
+
+        // This ensures that our load sampling mechanism is still somewhat
+        // meaningfull even though we never sleep.
+        if (wasBusy != isBusy) {
+
+            if (wasBusy && !isBusy) sleepStart = beforePoll;
+
+            // We don't want to include the time we spent doing stuff.
+            else totalSleepTime[threadNum] += beforePoll - sleepStart;
+
+            wasBusy = isBusy;
+        }
+    }
+}
+
+void
+EndpointBase::
+doSleepPolling(int threadNum, int numThreads)
+{
+    handleEvents(0, -1, handleEvent);
+}
+
+int
+EndpointBase::
+modePollTimeout(enum PollingMode mode)
+    const
+{
+    return (mode == SLEEP_POLLING) ? -1 : 0;
 }
 
 } // namespace Datacratic

--- a/service/epoller.h
+++ b/service/epoller.h
@@ -33,6 +33,12 @@ struct Epoller: public AsyncEventSource {
 
     void close();
 
+    /** Set the timeout value used when calling epoll_wait. */
+    void setPollTimeout(int newTimeout)
+    {
+        timeout_ = newTimeout;
+    }
+    
     /** Add the given fd to multiplex fd.  It will repeatedly wake up the
         loop without being restarted.
     */
@@ -96,7 +102,7 @@ struct Epoller: public AsyncEventSource {
     virtual bool poll() const;
 
     virtual bool processOne();
-    
+
 private:
     /* Perform the fd addition and modification */
     void performAddFd(int fd, void * data, bool oneShot, bool restart);

--- a/service/testing/test_http_services.cc
+++ b/service/testing/test_http_services.cc
@@ -10,6 +10,7 @@ HttpService(const shared_ptr<ServiceProxies> & proxies)
       HttpEndpoint("http-test-service-ep"),
       portToUse(0), numReqs(0)
 {
+    HttpEndpoint::setPollingMode(EndpointBase::SLEEP_POLLING);
 }
 
 HttpService::


### PR DESCRIPTION
This patch enables the specificication of multiple polling modes and adds a
mode where Epoller is allowed to sleep. Accessorily, the looping has been
refactored into multiple methods.
The default behaviour does not change and no incompatible API change has
been made. Moreover this has been tested using the http_client_test. Those
enables me to mark this change as TRIVIAL with confidence.