### PR TITLE
PLAT-870: clarified polling mode interface

### DIFF
--- a/service/testing/test_http_services.cc
+++ b/service/testing/test_http_services.cc
@@ -10,7 +10,7 @@ HttpService(const shared_ptr<ServiceProxies> & proxies)
       HttpEndpoint("http-test-service-ep"),
       portToUse(0), numReqs(0)
 {
-    HttpEndpoint::setPollingMode(EndpointBase::SLEEP_POLLING);
+    HttpEndpoint::setPollingMode(EndpointBase::MIN_CPU_POLLING);
 }
 
 HttpService::


### PR DESCRIPTION
Details:
* gives more meaningful names to the polling mode enum
* MIN_CPU_POLLING mode handling sleeps with a timeout of 1 second rather than indefinitely
* added load measurements, similarly to MIN_CONTEXT_SWITCH_POLLING mode