### PR TITLE
PLAT-943: fixed rare deadlock in waitRunning

### DIFF
--- a/service/runner.cc
+++ b/service/runner.cc
@@ -493,12 +493,17 @@ doRunImpl(const vector<string> & command,
           const shared_ptr<InputSink> & stdOutSink,
           const shared_ptr<InputSink> & stdErrSink)
 {
+    /* "activeRequest" must be increased after "running_" is set, in order to
+       guarantee the continuity between "waitRunning" and "waitTermination".
+    */
+    bool oldRunning(running_);
+    running_ = true;
+    ML::futex_wake(running_);
     activeRequest_++;
     ML::futex_wake(activeRequest_);
-    if (running_) {
+    if (oldRunning) {
         throw ML::Exception("already running");
     }
-    running_ = true;
     startDate_ = Date::now();
     endDate_ = Date::negativeInfinity();
 

--- a/service/runner.h
+++ b/service/runner.h
@@ -151,8 +151,10 @@ struct Runner : public EpollLoop {
     */
     bool signal(int signum, bool mustSucceed = true);
 
-    /** Synchronous wait for the subprocess to be marked as started from the
-        MessageLoop thread.
+    /** Synchronous wait for the run request to be processed by the
+        MessageLoop thread. In multithreaded context, it will wait for the
+        "current" request, which may differ from the one that the caller thread
+        actually performed.
 
         Will wait for a maximum of secondsToWait seconds. Returns "true" when
         the condition was met or "false" in case of a timeout.


### PR DESCRIPTION
This would occur due to the number of pending requests being too high
compared to the number of active requests, due to an integer not being
incremented during the throwing of the exception.